### PR TITLE
Proposed edits to today's notes

### DIFF
--- a/meetings/2025-09-04-notes.md
+++ b/meetings/2025-09-04-notes.md
@@ -14,6 +14,12 @@ TSC members in attendance: all 13
 ### Tech Charter Vote
 - Adopt as-is: 13 aye, 0 nay, 0 abstain
 
+## Governance.md
+
+- After brief discussion and hearing some would abstain from vote, decided to
+  proceed with this one asynchronously and on the PR that contains the edits
+
+
 ## Renaming & Logistics?
 - Jade: If we change the name after Tech Charter is signed, can the LLC stay as "Chapel"?
     - Brad: TODO to ask this question. Assumes that it can be changed, but would anybody bother?

--- a/meetings/2025-09-04-notes.md
+++ b/meetings/2025-09-04-notes.md
@@ -1,16 +1,22 @@
+Chapel TSC: Kickoff Meeting
+===================
+
+TSC members in attendance: all 13
+
+
 ## Questions on the Technical Charter
 
 - Karlon: What is "Series Manager"?
-    - The person who owns the LLC
+    - The person who "owns"/administers the LLC
     - LF is very hands-off, so they'll only be active when there is abuse etc
 - Abhishek: Re committers: There are other ways for non-HPE to contribute: badges etc. Those can be plusses without making actual commiters from non-HPE people
 
 ### Tech Charter Vote
-- As-is: 13 aye, 0 nay, 0 abstain
+- Adopt as-is: 13 aye, 0 nay, 0 abstain
 
 ## Renaming & Logistics?
 - Jade: If we change the name after Tech Charter is signed, can the LLC stay as "Chapel"?
-    - Brad: TODO to ask this question. Assumes that it can be changed, but why would anybody bother?
+    - Brad: TODO to ask this question. Assumes that it can be changed, but would anybody bother?
     - Jade: Follow up: how public is the name?
         - Brad: Legally it is public. Practically speaking, if the language was called Cascade, and the technical charter stayed the same, not very many people would notice
 - Ben: Can the LLC be named something else other than Chapel? We can just call it CHPL for the time being to give us more flexibility.
@@ -18,10 +24,10 @@
     - Ben Followup: Our GH org is chapel-lang, will that need to change?
     - Brad: TODO will find the list of things that need to change and put it up somewhere TSC can see.
 - Elliot: LF didn't like Cascade, can you elaborate?
-    - Brad: Team was on board with it. HPE wasn't on board -- Cascade Dish Soap was brought up. So, we got stuck.
+    - Brad: Team was on board with it. HPE wasn't on board (e.g., Cascade Dish Soap). So, we got stuck.
         - Then asked LF during the HPSF transition, they said we can do whatever, but they'd need to review the name. And they were not OK with "Cascade".
         - Elliot: "Cascade" sounds like a generic term?
-            - Brad: LF's response was based on googling and not something legal. There were many projects with name "cascade" in.
+            - Brad: LF's response was based on search and not something legal. There were many tech projects with name "cascade" in.
 
 ---
 


### PR DESCRIPTION
* added description of meeting and TSC attendance count
* loosened up description of series manager to match uncertainty expressed in the meeting
* slight clarification to what we voted on
* added brief discussion on governance and decision to vote asynchronously through PR
* removed "why" from answer about renaming LLC.  I can understand why they would, but am not certain whether they would
* not sure if Cascade dish soap was literal or a f'r'instance so added some wiggle room
* changed googling to search for LF search as they may have used a more specialized tool (I'm not sure); clarified that concern was with tech projects (e.g., "Open Cascade") rather than arbitrary ones (e.g., dish soap :D )